### PR TITLE
Remove CryptoSwift dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "CryptoSwift",
-        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "e2bc81be54d71d566a52ca17c3983d141c30aa70",
-          "version": "1.3.3"
-        }
-      },
-      {
         "package": "Gzip",
         "repositoryURL": "https://github.com/1024jp/GzipSwift",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -5,21 +5,19 @@ import PackageDescription
 
 let package = Package(
     name: "XCLogParser",
-    platforms: [.macOS(.v10_13)],
+    platforms: [.macOS(.v10_15)],
     products: [
     	.executable(name: "xclogparser", targets: ["XCLogParserApp"]),
         .library(name: "XCLogParser", targets: ["XCLogParser"])
     ],
     dependencies: [
         .package(url: "https://github.com/1024jp/GzipSwift", from: "5.1.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .exact("1.3.3")),
         .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
     ],
     targets: [
         .target(
-            name:"XcodeHasher",
-            dependencies: ["CryptoSwift"]
+            name:"XcodeHasher"
         ),
         .target(
             name: "XCLogParser",

--- a/Sources/XcodeHasher/XcodeHasher.swift
+++ b/Sources/XcodeHasher/XcodeHasher.swift
@@ -18,7 +18,7 @@
 // under the License.
 
 import Foundation
-import CryptoSwift
+import CryptoKit
 
 // Thanks to https://pewpewthespells.com/blog/xcode_deriveddata_hashes.html for
 // the initial Objective-C implementation.
@@ -33,7 +33,13 @@ public class XcodeHasher {
         var result = Array(repeating: "", count: 28)
 
         // Compute md5 hash of the path
-        let digest = path.bytes.md5()
+        let pathAsData = path.data(using: String.Encoding.utf8, allowLossyConversion: true)
+        let pathBytes = pathAsData != nil ? Array(pathAsData!) : Array(path.utf8)
+        let hash = Insecure.MD5.hash(data: pathBytes)
+        var digest: [UInt8] = []
+        hash.withUnsafeBytes { bufferPointer in
+            digest = Array(bufferPointer[0..<Insecure.MD5.byteCount])
+        }
 
         // Split 16 bytes into two chunks of 8 bytes each.
         let partitions = stride(from: 0, to: digest.count, by: 8).map {


### PR DESCRIPTION
`CryptoSwift` files are the slowest-compiling files in one of my projects that uses `XCLogParser`. I'm hoping that removing `CryptoSwift` as a dependency and inlining the MD5 computation will help reduce my compilation time.